### PR TITLE
Make GradleStartCommon compilable with Java 6

### DIFF
--- a/src/main/resources/net/minecraftforge/gradle/GradleStartCommon.java
+++ b/src/main/resources/net/minecraftforge/gradle/GradleStartCommon.java
@@ -109,7 +109,7 @@ public abstract class GradleStartCommon {
     }
 
     private String[] getArgs() {
-        ArrayList<String> list = new ArrayList<>(22);
+        ArrayList<String> list = new ArrayList<String>(22);
 
         for (Map.Entry<String, String> e : this.argMap.entrySet()) {
             String val = e.getValue();
@@ -251,7 +251,7 @@ public abstract class GradleStartCommon {
             // NO-OP
         }
 
-        List<String> grimPatches = new ArrayList<>();
+        List<String> grimPatches = new ArrayList<String>();
 
         for (URL url : ((URLClassLoader) GradleStartCommon.class.getClassLoader()).getURLs()) {
             if (!url.getProtocol().startsWith("file"))


### PR DESCRIPTION
Because this:
![image](https://user-images.githubusercontent.com/47505981/117789404-9b6e0400-b248-11eb-9b53-26c2353702ad.png)