### PR TITLE
Here be Grimoire shenanigans

### DIFF
--- a/src/main/java/net/minecraftforge/gradle/user/patch/UserPatchBasePlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/user/patch/UserPatchBasePlugin.java
@@ -1,5 +1,40 @@
 package net.minecraftforge.gradle.user.patch;
 
+import static net.minecraftforge.gradle.common.Constants.JAR_MERGED;
+import static net.minecraftforge.gradle.user.UserConstants.CLASSIFIER_DECOMPILED;
+import static net.minecraftforge.gradle.user.patch.UserPatchConstants.BINARIES_JAR;
+import static net.minecraftforge.gradle.user.patch.UserPatchConstants.BINPATCHES;
+import static net.minecraftforge.gradle.user.patch.UserPatchConstants.CLASSIFIER_PATCHED;
+import static net.minecraftforge.gradle.user.patch.UserPatchConstants.ECLIPSE_LOCATION;
+import static net.minecraftforge.gradle.user.patch.UserPatchConstants.JAR_BINPATCHED;
+import static net.minecraftforge.gradle.user.patch.UserPatchConstants.JSON;
+import static net.minecraftforge.gradle.user.patch.UserPatchConstants.RES_DIR;
+import static net.minecraftforge.gradle.user.patch.UserPatchConstants.START_DIR;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.tools.ant.filters.ReplaceTokens;
+import org.apache.tools.ant.types.Commandline;
+import org.gradle.api.Action;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.tasks.Copy;
+import org.gradle.api.tasks.Delete;
+import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.bundling.Jar;
+import org.gradle.api.tasks.compile.JavaCompile;
+import org.gradle.language.jvm.tasks.ProcessResources;
+
 import net.minecraftforge.gradle.StringUtils;
 import net.minecraftforge.gradle.common.Constants;
 import net.minecraftforge.gradle.delayed.DelayedFile;
@@ -7,27 +42,9 @@ import net.minecraftforge.gradle.tasks.ProcessJarTask;
 import net.minecraftforge.gradle.tasks.ProcessSrcJarTask;
 import net.minecraftforge.gradle.tasks.RemapSourcesTask;
 import net.minecraftforge.gradle.tasks.user.ApplyBinPatchesTask;
+import net.minecraftforge.gradle.tasks.user.reobf.ReobfTask;
 import net.minecraftforge.gradle.user.UserBasePlugin;
 import net.minecraftforge.gradle.user.UserConstants;
-import org.apache.tools.ant.types.Commandline;
-import org.gradle.api.Action;
-import org.gradle.api.DefaultTask;
-import org.gradle.api.Project;
-import org.gradle.api.plugins.JavaPluginConvention;
-import org.gradle.api.tasks.SourceSet;
-import org.gradle.api.tasks.TaskAction;
-
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
-import static net.minecraftforge.gradle.common.Constants.JAR_MERGED;
-import static net.minecraftforge.gradle.user.UserConstants.CLASSIFIER_DECOMPILED;
-import static net.minecraftforge.gradle.user.patch.UserPatchConstants.*;
 
 public abstract class UserPatchBasePlugin extends UserBasePlugin<UserPatchExtension> {
     @SuppressWarnings({"unchecked", "rawtypes"})
@@ -37,72 +54,71 @@ public abstract class UserPatchBasePlugin extends UserBasePlugin<UserPatchExtens
 
         // add the binPatching task
         {
-            ApplyBinPatchesTask task = makeTask("applyBinPatches", ApplyBinPatchesTask.class);
-            task.setInJar(delayedFile(JAR_MERGED));
-            task.setOutJar(delayedFile(JAR_BINPATCHED));
-            task.setPatches(delayedFile(BINPATCHES));
-            task.setClassesJar(delayedFile(BINARIES_JAR));
-            task.setResources(delayedFileTree(RES_DIR));
+            ApplyBinPatchesTask task = this.makeTask("applyBinPatches", ApplyBinPatchesTask.class);
+            task.setInJar(this.delayedFile(JAR_MERGED));
+            task.setOutJar(this.delayedFile(JAR_BINPATCHED));
+            task.setPatches(this.delayedFile(BINPATCHES));
+            task.setClassesJar(this.delayedFile(BINARIES_JAR));
+            task.setResources(this.delayedFileTree(RES_DIR));
             task.dependsOn("mergeJars");
 
-            project.getTasks().getByName("deobfBinJar").dependsOn(task);
+            this.project.getTasks().getByName("deobfBinJar").dependsOn(task);
 
-            ProcessJarTask deobf = (ProcessJarTask) project.getTasks().getByName("deobfBinJar").dependsOn(task);
+            ProcessJarTask deobf = (ProcessJarTask) this.project.getTasks().getByName("deobfBinJar").dependsOn(task);
             ;
-            deobf.setInJar(delayedFile(JAR_BINPATCHED));
+            deobf.setInJar(this.delayedFile(JAR_BINPATCHED));
             deobf.dependsOn(task);
         }
 
         // add source patching task
         {
-            DelayedFile decompOut = delayedDirtyFile(null, CLASSIFIER_DECOMPILED, "jar", false);
-            DelayedFile processed = delayedDirtyFile(null, CLASSIFIER_PATCHED, "jar", false);
+            DelayedFile decompOut = this.delayedDirtyFile(null, CLASSIFIER_DECOMPILED, "jar", false);
+            DelayedFile processed = this.delayedDirtyFile(null, CLASSIFIER_PATCHED, "jar", false);
 
-            ProcessSrcJarTask patch = makeTask("processSources", ProcessSrcJarTask.class);
+            ProcessSrcJarTask patch = this.makeTask("processSources", ProcessSrcJarTask.class);
             patch.dependsOn("decompile");
             patch.setInJar(decompOut);
             patch.setOutJar(processed);
-            configurePatching(patch);
+            this.configurePatching(patch);
 
-            RemapSourcesTask remap = (RemapSourcesTask) project.getTasks().getByName("remapJar");
+            RemapSourcesTask remap = (RemapSourcesTask) this.project.getTasks().getByName("remapJar");
             remap.setInJar(processed);
             remap.dependsOn(patch);
         }
-        
+
         // Delete old .classpath file, because we need it fresh and clean
-        project.getTasks().getByName("eclipse").dependsOn(makeTask("deleteEclipseClasspath", DeleteClasspathTask.class));
-        
+        this.project.getTasks().getByName("eclipse").dependsOn(this.makeTask("deleteEclipseClasspath", DeleteClasspathTask.class));
+
         // configure eclipse task to do extra stuff.
-        project.getTasks().getByName("eclipse").doLast(new Action() {
+        this.project.getTasks().getByName("eclipse").doLast(new Action() {
 
             @Override
             public void execute(Object arg0) {
-            	// BEGIN JEBANYE KOSTILY FOR ECLIPSE .CLASSPATH
-            	
-				try {
-					File classpath = new File(project.getProjectDir(), ".classpath");
-					if (classpath.exists() && classpath.isFile()) {
-						project.getLogger().lifecycle("Located new Eclipse .classpath file: " + classpath);						
-					}
-					
-					if (StringUtils.replaceContainingString(classpath.toPath(), "bin",  "bin/default",  "bin/main")) {
-						project.getLogger().lifecycle("Successfully rectified duplicate output paths in .classpath");
-					} else
-						project.getLogger().lifecycle("Could not rectify duplicate output paths in .classpath; not found");
-				} catch (Exception ex) {
-					project.getLogger().error("Error when patching .classpath file:");
-					project.getLogger().error(ex.toString());
-				}
-				
-            	// END JEBANYE KOSTILY FOR ECLIPSE .CLASSPATH
-            	
-            	
+                // BEGIN JEBANYE KOSTILY FOR ECLIPSE .CLASSPATH
+
+                try {
+                    File classpath = new File(UserPatchBasePlugin.this.project.getProjectDir(), ".classpath");
+                    if (classpath.exists() && classpath.isFile()) {
+                        UserPatchBasePlugin.this.project.getLogger().lifecycle("Located new Eclipse .classpath file: " + classpath);
+                    }
+
+                    if (StringUtils.replaceContainingString(classpath.toPath(), "bin",  "bin/default",  "bin/main")) {
+                        UserPatchBasePlugin.this.project.getLogger().lifecycle("Successfully rectified duplicate output paths in .classpath");
+                    } else {
+                        UserPatchBasePlugin.this.project.getLogger().lifecycle("Could not rectify duplicate output paths in .classpath; not found");
+                    }
+                } catch (Exception ex) {
+                    UserPatchBasePlugin.this.project.getLogger().error("Error when patching .classpath file:");
+                    UserPatchBasePlugin.this.project.getLogger().error(ex.toString());
+                }
+
+                // END JEBANYE KOSTILY FOR ECLIPSE .CLASSPATH
+
+
                 // find the file
                 File f = new File(ECLIPSE_LOCATION);
-                if (!f.exists()) // folder doesnt exist
-                {
+                if (!f.exists())
                     return;
-                }
                 File[] files = f.listFiles();
                 if (files.length < 1) // empty folder
                     return;
@@ -111,7 +127,7 @@ public abstract class UserPatchBasePlugin extends UserBasePlugin<UserPatchExtens
 
                 if (f.exists()) // if .location exists
                 {
-                    String projectDir = "URI//" + project.getProjectDir().toURI().toString();
+                    String projectDir = "URI//" + UserPatchBasePlugin.this.project.getProjectDir().toURI().toString();
                     try {
                         byte[] LOCATION_BEFORE = new byte[]{0x40, (byte) 0xB1, (byte) 0x8B, (byte) 0x81, 0x23, (byte) 0xBC, 0x00, 0x14, 0x1A, 0x25, (byte) 0x96, (byte) 0xE7, (byte) 0xA3, (byte) 0x93, (byte) 0xBE, 0x1E};
                         byte[] LOCATION_AFTER = new byte[]{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, (byte) 0xC0, 0x58, (byte) 0xFB, (byte) 0xF3, 0x23, (byte) 0xBC, 0x00, 0x14, 0x1A, 0x51, (byte) 0xF3, (byte) 0x8C, 0x7B, (byte) 0xBB, 0x77, (byte) 0xC6};
@@ -130,10 +146,118 @@ public abstract class UserPatchBasePlugin extends UserBasePlugin<UserPatchExtens
             }
 
         });
+
+        // Make sure to clear build cache before compiling/processing classes/resources.
+        // Required for proper inflation/token replacement when building
+        this.project.getTasks().getByName("sourceMainJava").dependsOn(this.makeTask("clearBuildCache", ClearBuildTask.class));
+        this.project.getTasks().getByName("processResources").dependsOn(this.makeTask("clearResourcesCache", ClearResourcesTask.class));
+
+        // Setting custom archive classifiers for some reason causes Gradle to clean
+        // build output right before reobf task is executed. This should help prevent it
+        ReobfTask reobf = (ReobfTask) this.project.getTasks().getByName("reobf");
+        reobf.getInputs().dir(this.project.getBuildDir());
+        reobf.getOutputs().dir(this.project.getBuildDir());
+
+        Task test = this.project.getTasks().getByName("test");
+        test.getInputs().dir(this.project.getBuildDir());
+        test.getOutputs().dir(this.project.getBuildDir());
+
+        // Check if user enabled our incredibly very shenanigans and make them happen if so
+        if (this.areGrimoireShenanigansEnabled()) {
+            this.applyGrimoireShenanigans();
+        }
+
+        // Inform the user whether or not Grimoire shenanigans are enabled.
+        // Doing this after evaluate so that banner gets printed first
+        this.project.afterEvaluate(new Action() {
+
+            @Override
+            public void execute(Object arg) {
+                UserPatchBasePlugin.this.project.getLogger().lifecycle("Grimoire shenanigans " +
+                        (UserPatchBasePlugin.this.areGrimoireShenanigansEnabled() ? "enabled" : "disabled"));
+
+                if (UserPatchBasePlugin.this.areGrimoireShenanigansEnabled()) {
+                    UserPatchBasePlugin.this.project.getLogger().lifecycle("Using Mixin refmap name: " +
+                            UserPatchBasePlugin.this.getMixinRefmapName());
+                }
+            }
+
+        });
+
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    protected void applyGrimoireShenanigans() {
+        // Add important repositories for Mixin annotation processor
+        this.addMavenRepo(this.project, "spongepowered-repo", "https://repo.spongepowered.org/maven/");
+        this.project.getRepositories().mavenCentral();
+
+        // Make custom task for copying srg-files into build/srgs directory
+        CopySrgsTask copyTask = this.makeTask("copySrgs", CopySrgsTask.class);
+        copyTask.init(this);
+        copyTask.dependsOn("genSrgs");
+
+        JavaCompile compileJava = (JavaCompile) this.project.getTasks().getByName("compileJava");
+        compileJava.dependsOn(copyTask);
+
+        // Add annotation processor for... annotation processing, I suppose
+        this.project.getDependencies().add("annotationProcessor", "org.spongepowered:mixin:0.7.11-SNAPSHOT");
+
+        // Create directory and srg/refmap output files for Mixin annotation processor
+        this.project.file(this.project.getBuildDir().getName() + "/mixins").mkdirs();
+        File mixinSrg = this.project.file(this.project.getBuildDir().getName() + "/mixins/mixins." + this.project.getName() + ".srg");
+        File mixinRefMap = this.project.file(this.project.getBuildDir().getName() + "/mixins/" + this.getMixinRefmapName());
+
+        // We probably don't need this, but having it will allow to interact with these
+        // properties through buildscript. Probably. Why? Why not.
+        this.project.getExtensions().getExtraProperties().set("mixinSrg", mixinSrg);
+        this.project.getExtensions().getExtraProperties().set("mixinRefMap", mixinRefMap);
+
+        // Add compiler args to point annotation processor to its input/output files
+        try {
+            List<String> compilerArgs = compileJava.getOptions().getCompilerArgs();
+            compilerArgs.add("-Xlint:-processing");
+            compilerArgs.add("-AoutSrgFile=" + mixinSrg.getCanonicalPath());
+            compilerArgs.add("-AoutRefMapFile=" + mixinRefMap.getCanonicalPath());
+            compilerArgs.add("-AreobfSrgFile=" + this.project.file(this.project.getBuildDir().getName() + "/srgs/mcp-srg.srg").getCanonicalPath());
+            compileJava.getOptions().setCompilerArgs(compilerArgs);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        // Make sure default .jar artifact will embed our glorious refmap we've been putting together
+        Jar jarTask = (Jar) this.project.getTasks().getByName("jar");
+        jarTask.from(mixinRefMap);
+
+        // Why do we need this one again?..
+        ReobfTask reobf = (ReobfTask) this.project.getTasks().getByName("reobf");
+        reobf.addExtraSrgFile(mixinSrg);
+
+        // Automatically replace any @MIXIN_REFMAP@ tokens in project resources
+        ProcessResources processResources = (ProcessResources) this.project.getTasks().getByName("processResources");
+        Map<String, Object> propertyMap = new LinkedHashMap<String, Object>();
+        Map<String, String> tokenMap = new LinkedHashMap<String, String>();
+        tokenMap.put("MIXIN_REFMAP", this.getMixinRefmapName());
+        propertyMap.put("tokens", tokenMap);
+
+        processResources.filter(propertyMap, ReplaceTokens.class);
+    }
+
+    public boolean areGrimoireShenanigansEnabled() {
+        return Boolean.parseBoolean(String.valueOf(this.project.getProperties().get("enableGrimoireShenanigans")));
+    }
+
+    public String getMixinRefmapName() {
+        // Allow users to define their own refmap name if they wish
+        if (this.project.hasProperty("mixinRefmapName"))
+            return String.valueOf(this.project.getProperties().get("mixinRefmapName"));
+        else
+            return this.project.getName() + ".refmap.json";
     }
 
     @Override
     public final void applyOverlayPlugin() {
+        // NO-OP
     }
 
     @Override
@@ -149,26 +273,27 @@ public abstract class UserPatchBasePlugin extends UserBasePlugin<UserPatchExtens
     /**
      * Allows for the configuration of tasks in AfterEvaluate
      */
+    @Override
     protected void delayedTaskConfig() {
         // add src ATs
-        ProcessJarTask binDeobf = (ProcessJarTask) project.getTasks().getByName("deobfBinJar");
-        ProcessJarTask decompDeobf = (ProcessJarTask) project.getTasks().getByName("deobfuscateJar");
+        ProcessJarTask binDeobf = (ProcessJarTask) this.project.getTasks().getByName("deobfBinJar");
+        ProcessJarTask decompDeobf = (ProcessJarTask) this.project.getTasks().getByName("deobfuscateJar");
 
         // ATs from the ExtensionObject
-        Object[] extAts = getExtension().getAccessTransformers().toArray();
+        Object[] extAts = this.getExtension().getAccessTransformers().toArray();
         binDeobf.addTransformer(extAts);
         decompDeobf.addTransformer(extAts);
 
         // from the resources dirs
         {
-            JavaPluginConvention javaConv = (JavaPluginConvention) project.getConvention().getPlugins().get("java");
+            JavaPluginConvention javaConv = (JavaPluginConvention) this.project.getConvention().getPlugins().get("java");
 
             SourceSet main = javaConv.getSourceSets().getByName("main");
             SourceSet api = javaConv.getSourceSets().getByName("api");
 
             for (File at : main.getResources().getFiles()) {
                 if (at.getName().toLowerCase().endsWith("_at.cfg")) {
-                    project.getLogger().lifecycle("Found AccessTransformer in main resources: " + at.getName());
+                    this.project.getLogger().lifecycle("Found AccessTransformer in main resources: " + at.getName());
                     binDeobf.addTransformer(at);
                     decompDeobf.addTransformer(at);
                 }
@@ -176,7 +301,7 @@ public abstract class UserPatchBasePlugin extends UserBasePlugin<UserPatchExtens
 
             for (File at : api.getResources().getFiles()) {
                 if (at.getName().toLowerCase().endsWith("_at.cfg")) {
-                    project.getLogger().lifecycle("Found AccessTransformer in api resources: " + at.getName());
+                    this.project.getLogger().lifecycle("Found AccessTransformer in api resources: " + at.getName());
                     binDeobf.addTransformer(at);
                     decompDeobf.addTransformer(at);
                 }
@@ -184,8 +309,8 @@ public abstract class UserPatchBasePlugin extends UserBasePlugin<UserPatchExtens
         }
 
         // configure fuzzing.
-        ProcessSrcJarTask patch = (ProcessSrcJarTask) project.getTasks().getByName("processSources");
-        patch.setMaxFuzz(getExtension().getMaxFuzz());
+        ProcessSrcJarTask patch = (ProcessSrcJarTask) this.project.getTasks().getByName("processSources");
+        patch.setMaxFuzz(this.getExtension().getMaxFuzz());
 
         super.delayedTaskConfig();
     }
@@ -193,27 +318,29 @@ public abstract class UserPatchBasePlugin extends UserBasePlugin<UserPatchExtens
     @Override
     protected void doVersionChecks(String version) {
         if (version.indexOf('-') > 0)
+        {
             version = version.split("-")[1]; // We get passed the full version, including MC ver and branch, we only want api's version.
+        }
         int buildNumber = Integer.parseInt(version.substring(version.lastIndexOf('.') + 1));
 
-        doVersionChecks(version, buildNumber);
+        this.doVersionChecks(version, buildNumber);
     }
 
     protected abstract void doVersionChecks(String version, int buildNumber);
 
     @Override
     protected DelayedFile getDevJson() {
-        return delayedFile(JSON);
+        return this.delayedFile(JSON);
     }
 
     @Override
     protected String getSrcDepName() {
-        return getApiName() + "Src";
+        return this.getApiName() + "Src";
     }
 
     @Override
     protected String getBinDepName() {
-        return getApiName() + "Bin";
+        return this.getApiName() + "Bin";
     }
 
     @Override
@@ -223,7 +350,7 @@ public abstract class UserPatchBasePlugin extends UserBasePlugin<UserPatchExtens
 
     @Override
     protected String getApiCacheDir(UserPatchExtension exten) {
-        return "{CACHE_DIR}/minecraft/" + getApiPath(exten) + "/{API_NAME}/{API_VERSION}";
+        return "{CACHE_DIR}/minecraft/" + this.getApiPath(exten) + "/{API_NAME}/{API_VERSION}";
     }
 
     @Override
@@ -238,7 +365,7 @@ public abstract class UserPatchBasePlugin extends UserBasePlugin<UserPatchExtens
 
     @Override
     protected String getUserDev() {
-        return getApiGroup() + ":{API_NAME}:{API_VERSION}";
+        return this.getApiGroup() + ":{API_NAME}:{API_VERSION}";
     }
 
     @Override
@@ -265,13 +392,13 @@ public abstract class UserPatchBasePlugin extends UserBasePlugin<UserPatchExtens
 
     @Override
     protected Iterable<String> getClientRunArgs() {
-        return getRunArgsFromProperty();
+        return this.getRunArgsFromProperty();
         //return ImmutableList.of("--version", "1.7", "--tweakClass", "cpw.mods.fml.common.launcher.FMLTweaker", "--username=ForgeDevName", "--accessToken", "FML", "--userProperties={}");
     }
 
     private Iterable<String> getRunArgsFromProperty() {
         List<String> ret = new ArrayList<String>();
-        String arg = (String) project.getProperties().get("runArgs");
+        String arg = (String) this.project.getProperties().get("runArgs");
         if (arg != null) {
             ret.addAll(Arrays.asList(Commandline.translateCommandline(arg)));
         }
@@ -280,7 +407,7 @@ public abstract class UserPatchBasePlugin extends UserBasePlugin<UserPatchExtens
 
     @Override
     protected Iterable<String> getServerRunArgs() {
-        return getRunArgsFromProperty();
+        return this.getRunArgsFromProperty();
     }
 
     /**
@@ -305,7 +432,7 @@ public abstract class UserPatchBasePlugin extends UserBasePlugin<UserPatchExtens
      * @return api path
      */
     protected String getApiPath(UserPatchExtension exten) {
-        return getApiGroup().replace('.', '/');
+        return this.getApiGroup().replace('.', '/');
     }
 
     @Override
@@ -330,16 +457,16 @@ public abstract class UserPatchBasePlugin extends UserBasePlugin<UserPatchExtens
 
     @Override
     protected String getServerRunClass() {
-        return getClientRunClass();
+        return this.getClientRunClass();
     }
 
     @Override
     public String resolve(String pattern, Project project, UserPatchExtension exten) {
         // override tweaker and server run class.
         // do run config stuff.
-        String prefix = getMcVersion(exten).startsWith("1.8") ? "net.minecraftforge." : "cpw.mods.";
-        pattern = pattern.replace("{RUN_CLIENT_TWEAKER}", prefix + getClientTweaker());
-        pattern = pattern.replace("{RUN_SERVER_TWEAKER}", prefix + getServerTweaker());
+        String prefix = this.getMcVersion(exten).startsWith("1.8") ? "net.minecraftforge." : "cpw.mods.";
+        pattern = pattern.replace("{RUN_CLIENT_TWEAKER}", prefix + this.getClientTweaker());
+        pattern = pattern.replace("{RUN_SERVER_TWEAKER}", prefix + this.getServerTweaker());
 
         pattern = super.resolve(pattern, project, exten);
 
@@ -351,32 +478,64 @@ public abstract class UserPatchBasePlugin extends UserBasePlugin<UserPatchExtens
         super.configurePostDecomp(decomp, remove);
 
         if (decomp && remove) {
-            (project.getTasks().getByName("applyBinPatches")).onlyIf(Constants.CALL_FALSE);
+            (this.project.getTasks().getByName("applyBinPatches")).onlyIf(Constants.CALL_FALSE);
         }
     }
-    
+
+    public static class ClearBuildTask extends Delete {
+        public ClearBuildTask() {
+            super();
+            this.delete(this.getProject().file(this.getProject().getBuildDir().getName() + "/classes/main"));
+        }
+    }
+
+    public static class ClearResourcesTask extends Delete {
+        public ClearResourcesTask() {
+            super();
+            this.delete(this.getProject().file(this.getProject().getBuildDir().getName() + "/resources/main"));
+        }
+    }
+
+    public static class CopySrgsTask extends Copy {
+        public CopySrgsTask() {
+            super();
+        }
+
+        public void init(UserPatchBasePlugin forgePlugin) {
+            this.from(forgePlugin.delayedFile("{SRG_DIR}"));
+
+            this.include("**/*.srg");
+            this.into(this.getProject().getBuildDir().getName() + "/srgs");
+        }
+
+        @TaskAction
+        public void doTask() {
+            // NO-OP
+        }
+    }
+
     /**
      * Sgorel saray - gori i hata.
      * @author Integral
      */
-    
+
     public static class DeleteClasspathTask extends DefaultTask {
-    	public DeleteClasspathTask() {
-			super();
-		}
-    	
-    	@TaskAction
-    	public void doTask() {
-    		try {
-				File classpath = new File(this.getProject().getProjectDir(), ".classpath");
-				
-				if (classpath.exists() && classpath.isFile()) {
-					classpath.delete();
-					this.getProject().getLogger().lifecycle("Deleted old Eclipse .classpath file");
-				}
-			} catch (Exception ex) {
-				ex.printStackTrace();
-			}
-    	}
+        public DeleteClasspathTask() {
+            super();
+        }
+
+        @TaskAction
+        public void doTask() {
+            try {
+                File classpath = new File(this.getProject().getProjectDir(), ".classpath");
+
+                if (classpath.exists() && classpath.isFile()) {
+                    classpath.delete();
+                    this.getProject().getLogger().lifecycle("Deleted old Eclipse .classpath file");
+                }
+            } catch (Exception ex) {
+                ex.printStackTrace();
+            }
+        }
     }
 }

--- a/src/main/resources/net/minecraftforge/gradle/GradleStartCommon.java
+++ b/src/main/resources/net/minecraftforge/gradle/GradleStartCommon.java
@@ -251,6 +251,9 @@ public abstract class GradleStartCommon {
             // NO-OP
         }
 
+        LOGGER.info("Begin coremod and grimpatch search...");
+        long memorizedTime = System.currentTimeMillis();
+
         List<String> grimPatches = new ArrayList<String>();
 
         for (URL url : ((URLClassLoader) GradleStartCommon.class.getClassLoader()).getURLs()) {
@@ -328,6 +331,8 @@ public abstract class GradleStartCommon {
         if (grimPatches.size() > 0) { // If we have any patches, add them to properties or something
             System.setProperty(GRIMPATCH_VAR, Joiner.on("<@>").join(grimPatches));
         }
+
+        LOGGER.info("Finished coremod and grimpatch search, elapsed time: " + (System.currentTimeMillis() - memorizedTime) + "ms");
 
         // set property.
         Set<String> coremodsSet = Sets.newHashSet();


### PR DESCRIPTION
Diff has gone a little wild in certain places because of automatic `this.` qualifiers my workspace conveniently puts everywhere I go, but I expect this is not a great concern. I shall refrain from detailed commentary on every new change, since they already are commented in the code, but overall: 

This PR implements optional functionality required in Mixin-dependent workspaces, allowing to turn it on through project property `enableGrimoireShenanigans`, presumably put in `gradle.properties`. There also is another new property to manage refmap name. A couple general fixes/QoL features are also included.